### PR TITLE
Fix periodic autosave not working properly

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -48,6 +48,8 @@ function App() {
   const [moedaPrestigio, setMoedaPrestigio] = useState(0)
   const [multiplicadorPrestigio, setMultiplicadorPrestigio] = useState(1)
   const [nivelMultiplicadorPrestigio, setNivelMultiplicadorPrestigio] = useState(0)
+  const [saveAgain, setSaveAgain] = useState(false)
+  const [loading, setLoading] = useState(true)
 
   // Utilities 
 
@@ -960,26 +962,36 @@ function App() {
 
   // Load Inicial dos dados através dos Cookies
   useEffect(() => {
-    const encryptedSave = loadFromCookies();
-    if (encryptedSave) {
-      setAllStates(decryptSave(encryptedSave));
+    if (loading) {
+      const encryptedSave = loadFromCookies();
+      if (encryptedSave) {
+        setAllStates(decryptSave(encryptedSave));
+      }
+      setLoading(false);
     }
   }, []);
   
   // Save Automático a cada 1 minuto
   useEffect(() => {
-    const interval = setInterval(() => {
+    if (loading) return;
+    if (saveAgain) {
       saveToCookies(getAllStates());
-    }, AUTO_SAVE_INTERVAL); // 1 minuto
-
-    return () => clearInterval(interval);
-  }, []);
+      setSaveAgain(false)
+    } else {
+      setTimeout(() => {
+        setSaveAgain(true);
+      }, AUTO_SAVE_INTERVAL);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[saveAgain, loading]);
 
   // Save a cada compra de upgrade
   useEffect(() => {
+    if (loading) return;
     saveToCookies(getAllStates());
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nivelUpgrade1,
+  }, [loading,
+      nivelUpgrade1,
       nivelUpgrade2,
       nivelUpgrade3,  
       nivelUpgrade4,

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,5 +2,5 @@ export const COOKIES_KEY = 'edecio-clicker-saveData';
 export const COOKIES_EXPIRATION = 31536000; // 1 year expiration  // Chave secreta para criptografia
 export const SECRET_KEY = '1.0';
 export const SPLIT_COOKIE_AMOUNT = 3900; // 4kb limit per cookie
-export const AUTO_SAVE_INTERVAL = 30000; // 30 seconds
-export const AUTO_SAVE_TOLERANCE_AFTER_BUY = 5000; // 5 seconds
+export const AUTO_SAVE_INTERVAL = 15000; // 15 seconds
+export const AUTO_SAVE_TOLERANCE_AFTER_BUY = 3000; // 3 seconds

--- a/src/hooks/useCookiesSave.js
+++ b/src/hooks/useCookiesSave.js
@@ -18,7 +18,7 @@ function setCookies(saveData) {
 
   // Set each chunk as a separate cookie
   chunks.forEach((chunk, index) => {
-    document.cookie = `${COOKIES_KEY}_${index}=${encodeURIComponent(chunk)}; max-age=${COOKIES_EXPIRATION}`;
+    document.cookie = `${COOKIES_KEY}_${index}=${encodeURIComponent(chunk)}; max-age=${COOKIES_EXPIRATION}; SameSite=Strict`;
   });
 }
 


### PR DESCRIPTION
- Arruma um problema no auto-save periódico, que causava um reset não intencional ao carregar a página;
- Reduz os intervalos de saves;
- Adiciona SameSite=Strict nos headers dos cookies.